### PR TITLE
Import Aliasing

### DIFF
--- a/apps/client-api/tsconfig.json
+++ b/apps/client-api/tsconfig.json
@@ -1,5 +1,11 @@
 {
     "extends": "@repo/typescript-config/base.json",
     "exclude": ["node_modules"],
-    "include": ["src/**/*.ts", "tsup.config.ts"]
+    "include": ["src/**/*.ts", "tsup.config.ts"],
+    "compilerOptions": {
+        "baseUrl": "src/",
+        "paths": {
+            "@/*": ["*"],
+        }
+    }
 }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -5,7 +5,11 @@
         {
           "name": "next"
         }
-      ]
+      ],
+      "baseUrl": "src/",
+        "paths": {
+            "@/*": ["*"],
+        },
     },
     "include": [
       "next-env.d.ts",


### PR DESCRIPTION
Overdue, but now we can do import aliasing in our apps. 

For example:
```
import { myFunc } from '../../../../../utils/helpers.ts';
```
becomes 
```
import { myFunc } from '@/utils/helpers.ts';
```